### PR TITLE
fix: add const qualifier to serialize and deserialize methods

### DIFF
--- a/src/modules/protocol/iprotocol/internals/ideserializer.hpp
+++ b/src/modules/protocol/iprotocol/internals/ideserializer.hpp
@@ -25,6 +25,6 @@ public:
      * @param input std::any object with serialized message
      * @return Message object with deserialized message
      */
-    virtual Message deserialize(const std::any& input) = 0;
+    virtual Message deserialize(const std::any& input) const = 0;
 };
 

--- a/src/modules/protocol/iprotocol/internals/iserializer.hpp
+++ b/src/modules/protocol/iprotocol/internals/iserializer.hpp
@@ -25,6 +25,6 @@ public:
      * @param msg Message struct
      * @return std::any object with serialized message
      */
-    virtual std::any serialize(const Message& msg) = 0;
+    virtual std::any serialize(const Message& msg) const = 0;
 };
 

--- a/src/modules/protocol/jsonprotocol/jsonprotocol.cpp
+++ b/src/modules/protocol/jsonprotocol/jsonprotocol.cpp
@@ -9,7 +9,7 @@
 
 
 
-std::any JsonProtocol::serialize(const Message& msg)
+std::any JsonProtocol::serialize(const Message& msg) const
 {
     uint64_t timestamp_minutes =
         std::chrono::duration_cast<std::chrono::minutes>(msg.send_time.time_since_epoch()).count();
@@ -26,7 +26,7 @@ std::any JsonProtocol::serialize(const Message& msg)
 
 
 
-Message JsonProtocol::deserialize(const std::any& input)
+Message JsonProtocol::deserialize(const std::any& input) const
 {
     Json::Value root = std::any_cast<Json::Value>(input);
 

--- a/src/modules/protocol/jsonprotocol/jsonprotocol.hpp
+++ b/src/modules/protocol/jsonprotocol/jsonprotocol.hpp
@@ -20,7 +20,7 @@ public:
      * @param msg Message
      * @return std::any with Json::Value inside
      */
-    std::any serialize(const Message& msg) override;
+    std::any serialize(const Message& msg) const override;
 
 
     /**
@@ -28,5 +28,5 @@ public:
      * @param input std::any with Json::Value inside
      * @return Message
      */
-    Message deserialize(const std::any& input) override;
+    Message deserialize(const std::any& input) const override;
 };


### PR DESCRIPTION
This allows you to cause these methods from constant objects. The internally state of the object does not change