### PR TITLE
perf, transport: The callback in JsonTransport::run_receiving_message…

### DIFF
--- a/src/modules/transport/itransport/itransport.hpp
+++ b/src/modules/transport/itransport/itransport.hpp
@@ -23,7 +23,7 @@ public:
      * @param callback Callback which will be called upon receipt of a new message
      */
     virtual void run_receiving_messages_async(
-        std::function<void(decltype(std::declval<IProtocol>().deserialize(std::any())))> callback) const = 0;
+        std::function<void(const decltype(std::declval<IProtocol>().deserialize(std::any()))&)> callback) const = 0;
 
 
     /**

--- a/src/modules/transport/jsontransport/jsontransport.cpp
+++ b/src/modules/transport/jsontransport/jsontransport.cpp
@@ -22,7 +22,7 @@ JsonTransport::JsonTransport(const JsonProtocol &protocol) : protocol_(protocol)
 
 /* public method */
 void JsonTransport::run_receiving_messages_async(
-    std::function<void(decltype(std::declval<IProtocol>().deserialize(std::any())))> callback) const
+    std::function<void(const decltype(std::declval<IProtocol>().deserialize(std::any()))&)> callback) const
 {
     static bool running = false;
 

--- a/src/modules/transport/jsontransport/jsontransport.hpp
+++ b/src/modules/transport/jsontransport/jsontransport.hpp
@@ -27,7 +27,8 @@ public:
      * @param callback Callback which will be called upon receipt of the request
      */
     void run_receiving_messages_async(
-        std::function<void(decltype(std::declval<IProtocol>().deserialize(std::any())))> callback) const override;
+        std::function<void(const decltype(std::declval<IProtocol>().deserialize(std::any()))&)> callback)
+        const override;
 
 
     /**


### PR DESCRIPTION
…s_async now accepts a constant reference argument.